### PR TITLE
Fixing csrf authentication with OASP4J archetypes

### DIFF
--- a/src/app/core/security/login.service.ts
+++ b/src/app/core/security/login.service.ts
@@ -33,8 +33,8 @@ export class LoginService {
     return this.http.post(
       this.BO.login(),
       {
-        username: username,
-        password: password,
+        j_username: username,
+        j_password: password,
       },
       options,
     );


### PR DESCRIPTION
This pull request fixes the authentication of this Angular app with OASP4J back end servers. As by default the archetype defines variables `j_username` and `j_password`, we need to change them on the front end side so that the login is possible.

Correspondingly, I will change the Ionic JWT back end and the Ionic front end. 