### PR TITLE
Adding Spring pageable to the template

### DIFF
--- a/src/app/core/interfaces/page-data.ts
+++ b/src/app/core/interfaces/page-data.ts
@@ -1,9 +1,0 @@
-export interface PageData {
-  pagination: {
-    size: number;
-    page: number;
-    total: number;
-  };
-  sort: any[];
-  [propName: string]: any;
-}

--- a/src/app/core/interfaces/pageable.ts
+++ b/src/app/core/interfaces/pageable.ts
@@ -1,0 +1,7 @@
+import { Sort } from "./sort";
+
+export interface Pageable {
+  pageSize: number;
+  pageNumber: number;
+  sort?: Array<Sort>;
+}

--- a/src/app/core/interfaces/pagination.ts
+++ b/src/app/core/interfaces/pagination.ts
@@ -1,5 +1,0 @@
-export interface Pagination {
-  size: number;
-  page: number;
-  total: number;
-}

--- a/src/app/core/interfaces/search-criteria.ts
+++ b/src/app/core/interfaces/search-criteria.ts
@@ -1,0 +1,6 @@
+import { Pageable } from "./pageable";
+
+export interface SearchCriteria {
+  pageable: Pageable;
+  [propName: string]: any;
+}

--- a/src/app/core/interfaces/sort.ts
+++ b/src/app/core/interfaces/sort.ts
@@ -1,0 +1,5 @@
+export interface Sort {
+    direction: String;
+    property: String;
+  }
+  

--- a/src/app/sampledata/sampledata-grid/sampledata-grid.component.ts
+++ b/src/app/sampledata/sampledata-grid/sampledata-grid.component.ts
@@ -79,10 +79,10 @@ export class SampleDataGridComponent implements OnInit {
   getSampleData(): void {
     this.dataGridService
       .getSampleData(
-        this.pageSize,
+        this.pageable.pageSize,
         this.pageable.pageNumber,
         this.searchTerms,
-        this.sorting,
+        this.pageable.sort = this.sorting,
       )
       .subscribe(
         (res: any) => {
@@ -131,7 +131,7 @@ export class SampleDataGridComponent implements OnInit {
   sort(sortEvent: ITdDataTableSortChangeEvent): void {
     this.sorting = [];
     this.sorting.push({
-      name: sortEvent.name.split('.').pop(),
+      property: sortEvent.name.split('.').pop(),
       direction: '' + sortEvent.order,
     });
     this.getSampleData();

--- a/src/app/sampledata/sampledata-grid/sampledata-grid.component.ts
+++ b/src/app/sampledata/sampledata-grid/sampledata-grid.component.ts
@@ -22,7 +22,7 @@ import { Pageable } from '../../core/interfaces/pageable';
 export class SampleDataGridComponent implements OnInit {
   private pageable: Pageable = {
     pageSize: 8,
-    pageNumber: 1,
+    pageNumber: 0,
   };
   private sorting: any[] = [];
 
@@ -86,8 +86,8 @@ export class SampleDataGridComponent implements OnInit {
       )
       .subscribe(
         (res: any) => {
-          this.data = res.result;
-          this.totalItems = res.pageable.total;
+          this.data = res.content;
+          this.totalItems = res.pageable.pageSize;
           this.dataTable.refresh();
         },
         (error: any) => {
@@ -123,7 +123,8 @@ export class SampleDataGridComponent implements OnInit {
   page(pagingEvent: IPageChangeEvent): void {
     this.pageable = {
       pageSize: pagingEvent.pageSize,
-      pageNumber: pagingEvent.pageNumber,
+      pageNumber: pagingEvent.page,
+      sort: this.pageable.sort,
     };
     this.getSampleData();
   }

--- a/src/app/sampledata/sampledata-grid/sampledata-grid.component.ts
+++ b/src/app/sampledata/sampledata-grid/sampledata-grid.component.ts
@@ -87,7 +87,7 @@ export class SampleDataGridComponent implements OnInit {
       .subscribe(
         (res: any) => {
           this.data = res.content;
-          this.totalItems = res.pageable.pageSize;
+          this.totalItems = res.totalElements;
           this.dataTable.refresh();
         },
         (error: any) => {
@@ -123,7 +123,7 @@ export class SampleDataGridComponent implements OnInit {
   page(pagingEvent: IPageChangeEvent): void {
     this.pageable = {
       pageSize: pagingEvent.pageSize,
-      pageNumber: pagingEvent.page,
+      pageNumber: pagingEvent.page - 1,
       sort: this.pageable.sort,
     };
     this.getSampleData();

--- a/src/app/sampledata/sampledata-grid/sampledata-grid.component.ts
+++ b/src/app/sampledata/sampledata-grid/sampledata-grid.component.ts
@@ -12,7 +12,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { SampleDataService } from '../services/sampledata.service';
 import { AuthService } from '../../core/security/auth.service';
 import { SampleDataDialogComponent } from '../sampledata-dialog/sampledata-dialog.component';
-import { Pagination } from '../../core/interfaces/pagination';
+import { Pageable } from '../../core/interfaces/pageable';
 
 @Component({
   selector: 'public-sampledata-grid',
@@ -20,10 +20,9 @@ import { Pagination } from '../../core/interfaces/pagination';
   styleUrls: ['./sampledata-grid.component.scss'],
 })
 export class SampleDataGridComponent implements OnInit {
-  private pagination: Pagination = {
-    size: 8,
-    page: 1,
-    total: 1,
+  private pageable: Pageable = {
+    pageSize: 8,
+    pageNumber: 1,
   };
   private sorting: any[] = [];
 
@@ -81,14 +80,14 @@ export class SampleDataGridComponent implements OnInit {
     this.dataGridService
       .getSampleData(
         this.pageSize,
-        this.pagination.page,
+        this.pageable.pageNumber,
         this.searchTerms,
         this.sorting,
       )
       .subscribe(
         (res: any) => {
           this.data = res.result;
-          this.totalItems = res.pagination.total;
+          this.totalItems = res.pageable.total;
           this.dataTable.refresh();
         },
         (error: any) => {
@@ -122,10 +121,9 @@ export class SampleDataGridComponent implements OnInit {
     return value;
   }
   page(pagingEvent: IPageChangeEvent): void {
-    this.pagination = {
-      size: pagingEvent.pageSize,
-      page: pagingEvent.page,
-      total: 1,
+    this.pageable = {
+      pageSize: pagingEvent.pageSize,
+      pageNumber: pagingEvent.pageNumber,
     };
     this.getSampleData();
   }

--- a/src/app/sampledata/services/sampledata.service.ts
+++ b/src/app/sampledata/services/sampledata.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../environments/environment';
 import { Observable } from 'rxjs';
-import { PageData } from '../../core/interfaces/page-data';
+import { SearchCriteria } from '../../core/interfaces/search-criteria';
 
 @Injectable()
 export class SampleDataService {
@@ -15,19 +15,17 @@ export class SampleDataService {
     searchTerms: any,
     sort: any[],
   ): Observable<any> {
-    const pageData: PageData = {
-      pagination: {
-        size: size,
-        page: page,
-        total: 1,
+    const searchCriteria: SearchCriteria = {      
+      pageable: {
+        pageSize: size,
+        pageNumber: page,        
       },
       name: searchTerms.name,
       surname: searchTerms.surname,
       age: searchTerms.age,
       mail: searchTerms.mail,
-      sort: sort,
     };
-    return this.http.post<any>(this.urlService + 'search', pageData);
+    return this.http.post<any>(this.urlService + 'search', searchCriteria);
   }
 
   saveSampleData(data: any): Observable<Object> {

--- a/src/app/sampledata/services/sampledata.service.ts
+++ b/src/app/sampledata/services/sampledata.service.ts
@@ -18,7 +18,8 @@ export class SampleDataService {
     const searchCriteria: SearchCriteria = {      
       pageable: {
         pageSize: size,
-        pageNumber: page,        
+        pageNumber: page,
+        sort: sort,
       },
       name: searchTerms.name,
       surname: searchTerms.surname,

--- a/src/app/sampledata/services/sampledata.service.ts
+++ b/src/app/sampledata/services/sampledata.service.ts
@@ -31,6 +31,7 @@ export class SampleDataService {
   saveSampleData(data: any): Observable<Object> {
     const obj: any = {
       id: data.id,
+      modificationCounter: data.modificationCounter,
       name: data.name,
       surname: data.surname,
       age: data.age,


### PR DESCRIPTION
Addresses #3  

As with the new OASP4J 3.0.0 version we have decided to go for [Spring-data](https://github.com/oasp-forge/oasp4j-wiki/wiki/guide-repository), we needed to change the interfaces to fit the new Spring pagination logic.

This Pull Request also adds the `modificationCounter` attribute to the sampleData, so that the editing works fine even when multiple changes are done.